### PR TITLE
fix ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/src/select.component.ts
+++ b/src/select.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, Input, OnChanges, OnInit, Output, EventEmitter, ExistingProvider, ViewChild, ViewEncapsulation, forwardRef} from '@angular/core';
+import {Component, Input, OnChanges, OnInit, Output, EventEmitter, ExistingProvider, ViewChild, ViewEncapsulation, forwardRef} from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {STYLE} from './select.component.css';
 import {TEMPLATE} from './select.component.html';
@@ -22,7 +22,7 @@ export const SELECT_VALUE_ACCESSOR: ExistingProvider = {
 })
 
 export class SelectComponent
-        implements AfterViewInit, ControlValueAccessor, OnChanges, OnInit {
+        implements ControlValueAccessor, OnChanges, OnInit {
 
     @Input() options: Array<IOption>;
 
@@ -81,9 +81,6 @@ export class SelectComponent
 
     ngOnInit() {
         this.placeholderView = this.placeholder;
-    }
-
-    ngAfterViewInit() {
         this.updateFilterWidth();
     }
 


### PR DESCRIPTION
Fixes #143.
I think we should call `updateFilterWidth` in `ngOnInit` instead of `ngAfterViewInit`. 

The original value (1) of `filterInputWidth` gets bound to the underlying input element before `ngAfterViewInit` is called. If we call  `updateFilterWidth`, which updates `filterInputWidth`, in `ngAfterViewInit` we will change a bound input property in the middle of a change detection loop, which angular should detect in dev mode and throw ExpressionChangedAfterItHasBeenCheckedError.