### PR TITLE
Filter box in multiple select

### DIFF
--- a/src/select-dropdown.component.html
+++ b/src/select-dropdown.component.html
@@ -2,7 +2,7 @@
     [ngStyle]="{'top.px': top, 'left.px': left, 'width.px': width}">
 
     <div class="filter"
-        *ngIf="!multiple && filterEnabled">
+        *ngIf="filterEnabled">
         <input
             #filterInput
             autocomplete="off"


### PR DESCRIPTION
It's a simple modification that seems to give back the filter box to multiple select. I didn't investigate further in the history of changes you made, so maybe there is a reason to remove filter from multiple select that I don't understand. Anyway, thank you for this great work, till now this is the best plugin I've found for select.