### PR TITLE
Fixed issue with positioning and setting the width of the dropdown on decimal numbers

### DIFF
--- a/src/select-dropdown.component.scss
+++ b/src/select-dropdown.component.scss
@@ -12,7 +12,7 @@ select-dropdown {
         border: 1px solid #ccc;
         border-top: none;
         box-sizing: border-box;
-        position: absolute;
+        position: fixed;
         z-index: 1;
 
         .filter {
@@ -44,7 +44,7 @@ select-dropdown {
             }
         }
     }
-        
+
     .selected {
         background-color: #e0e0e0;
 

--- a/src/select.component.ts
+++ b/src/select.component.ts
@@ -487,13 +487,14 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
     }
 
     private updateWidth() {
-        this.width = this.selectionSpan.nativeElement.offsetWidth;
+        this.width = this.selectionSpan.nativeElement.getBoundingClientRect().width;
     }
 
     private updatePosition() {
         let e = this.selectionSpan.nativeElement;
-        this.left = e.offsetLeft;
-        this.top = e.offsetTop + e.offsetHeight;
+        let boundingClientRect = e.getBoundingClientRect();
+        this.left = boundingClientRect.left;
+        this.top = boundingClientRect.top + e.offsetHeight;
     }
 
     private updateFilterWidth() {

--- a/src/select.component.ts
+++ b/src/select.component.ts
@@ -491,10 +491,9 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
     }
 
     private updatePosition() {
-        let e = this.selectionSpan.nativeElement;
-        let boundingClientRect = e.getBoundingClientRect();
+        let boundingClientRect = this.selectionSpan.nativeElement.getBoundingClientRect();
         this.left = boundingClientRect.left;
-        this.top = boundingClientRect.top + e.offsetHeight;
+        this.top = boundingClientRect.top + boundingClientRect.height;
     }
 
     private updateFilterWidth() {


### PR DESCRIPTION
Currently, when setting the position and the width of the dropdown, offset(Width|Left|Top) is used.
The issue is that these properties only give integer values. In cases when the position or the width is a decimal number, 'Element.getBoundingClientRect()' is recommended to be used.

Plunker showing the issue: [DropdownIssue](https://plnkr.co/edit/Vdn1CuOhVSHPKveRNMsB?p=preview)

The dropdown is shown as smaller than the placeholder (maybe with some zoom-in will be more visible).