### PR TITLE
Fixed issue with positioning and setting the width of the dropdown on decimal number (absolute positioning)

### DIFF
--- a/src/select.component.ts
+++ b/src/select.component.ts
@@ -1,4 +1,5 @@
-import {Component, Input, OnChanges, OnInit, Output, EventEmitter, ExistingProvider, ViewChild, ViewEncapsulation, forwardRef} from '@angular/core';
+import {Component, Input, OnChanges, OnInit, Output, EventEmitter, ExistingProvider, ViewChild, ViewEncapsulation, forwardRef, ElementRef
+} from '@angular/core';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {STYLE} from './select.component.css';
 import {TEMPLATE} from './select.component.html';
@@ -73,6 +74,9 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
 
     private onChange = (_: any) => {};
     private onTouched = () => {};
+
+    constructor(private hostElement: ElementRef) {
+    }
 
     /** Event handlers. **/
 
@@ -487,13 +491,14 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
     }
 
     private updateWidth() {
-        this.width = this.selectionSpan.nativeElement.offsetWidth;
+        this.width = this.selectionSpan.nativeElement.getBoundingClientRect().width;
     }
 
     private updatePosition() {
-        let e = this.selectionSpan.nativeElement;
-        this.left = e.offsetLeft;
-        this.top = e.offsetTop + e.offsetHeight;
+        const hostBoundingClientRect = this.hostElement.nativeElement.getBoundingClientRect();
+        const spanBoundingClientRect = this.selectionSpan.nativeElement.getBoundingClientRect();
+        this.left = spanBoundingClientRect.left - hostBoundingClientRect.left;
+        this.top = (spanBoundingClientRect.top - hostBoundingClientRect.top) + spanBoundingClientRect.height;
     }
 
     private updateFilterWidth() {


### PR DESCRIPTION
Fixed issue with 'dropdown not scrolling with the page' introduced in https://github.com/basvandenberg/ng-select/pull/173 .
I apologize for this issue that I overlooked :)
In this PR, the positioning is 'absolute', and the top and left of the dropdown are calculated relative to the host element.