### PR TITLE
Allow Numbers in the ngModel

### DIFF
--- a/src/select.component.ts
+++ b/src/select.component.ts
@@ -259,8 +259,8 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
         if (typeof v === 'undefined' || v === null || v === '') {
             v = [];
         }
-        else if (typeof v === 'string') {
-            v = [v];
+        else if (typeof v === 'string' || typeof v === 'number') {
+            v = [v.toString()];
         }
         else if (!Array.isArray(v)) {
             throw new TypeError('Value must be a string or an array.');


### PR DESCRIPTION
Add- numbers. `"Value must be a string or an array."`
While using Enums or primitive number, `.toString()` wil convert to string so that the model can be more flexible.