### PR TITLE
Minor packaging fixes

### DIFF
--- a/copy_to_demo.sh
+++ b/copy_to_demo.sh
@@ -2,9 +2,9 @@
 rm -v src/app/ng-select/dist/ng-select-*.tgz
 rm -rv demo/node_modules/ng-select/*
 
-npm pack src/app/ng-select/dist
+npm pack dist
 tar -xzvf ng-select-*.tgz
 mv -v package/* demo/node_modules/ng-select/
 
 rm ng-select-*.tgz
-rmdir -v package
+rm -fRv package

--- a/ng-package.json
+++ b/ng-package.json
@@ -2,6 +2,6 @@
   "$schema": "./node_modules/ng-packagr/ng-package.schema.json",
   "src": "src/app/ng-select",
   "lib": {
-    "entryFile": "public_api.ts"
+    "entryFile": "src/app/ng-select/public_api.ts"
   }
 }


### PR DESCRIPTION
After cloning the repo today, I found that ng-packagr wouldn't work without these fixes. The script change is to reference the local (not deep) path to the generated ng-packagr dist directory.