### PR TITLE
Allow any type

### DIFF
--- a/src/app/ng-select/option.interface.ts
+++ b/src/app/ng-select/option.interface.ts
@@ -1,5 +1,5 @@
 export interface IOption {
-    value: string;
+    value: any;
     label: string;
     disabled?: boolean;
 }

--- a/src/app/ng-select/select.component.ts
+++ b/src/app/ng-select/select.component.ts
@@ -260,11 +260,8 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
         if (typeof v === 'undefined' || v === null || v === '') {
             v = [];
         }
-        else if (typeof v === 'string') {
-            v = [v];
-        }
         else if (!Array.isArray(v)) {
-            throw new TypeError('Value must be a string or an array.');
+            v = [v];
         }
 
         this.optionList.value = v;


### PR DESCRIPTION
Is there a technical reason why only strings are allowed? If I passing in options where the value is a complex object, it works fine. The only issue is if I try to set the value, the code throws an error saying only arrays or strings are allowed.

If you circumvent that check with the code in this PR, then everything works when I use any type for the value.

I think the only thing to consider is that the options need to be unique, which you could add a check for it. But mostly I wanted to open this PR to ask why the limitation on value type to only string.