### PR TITLE
Use readonly array for input options

### DIFF
--- a/projects/ng-select/src/lib/option-list.ts
+++ b/projects/ng-select/src/lib/option-list.ts
@@ -22,7 +22,7 @@ export class OptionList {
         return this._hasSelected;
     }
 
-    constructor(options: Array<IOption>) {
+    constructor(options: readonly IOption[]) {
 
         if (typeof options === 'undefined' || options === null) {
             options = [];

--- a/projects/ng-select/src/lib/select.component.ts
+++ b/projects/ng-select/src/lib/select.component.ts
@@ -22,7 +22,7 @@ export const SELECT_VALUE_ACCESSOR: ExistingProvider = {
 export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit {
 
     // Data input.
-    @Input() options: Array<IOption> = [];
+    @Input() options: readonly IOption[] = [];
 
     // Functionality settings.
     @Input() allowClear: boolean = false;
@@ -241,7 +241,7 @@ export class SelectComponent implements ControlValueAccessor, OnChanges, OnInit 
         }
     }
 
-    private updateOptionList(options: Array<IOption>) {
+    private updateOptionList(options: readonly IOption[]) {
         this.optionList = new OptionList(options);
         this.optionList.value = this._value;
     }


### PR DESCRIPTION
When using `op: readonly Options[] = [/* ... */]` as an input for ng-select, the type checker complains.

`readonly T[]` states that it is an array of `T` where no elements can be added or removed from the array.

Without this change, the library user cannot use a readonly array as input value.